### PR TITLE
Quote SQL literal when using row-based JDBC input

### DIFF
--- a/matlab/+cws/JDBCDataSource.m
+++ b/matlab/+cws/JDBCDataSource.m
@@ -874,7 +874,8 @@ classdef JDBCDataSource < handle & cws.DataSource % ++++++++++++++++++++++++++++
           continue;
         end
         %            sqlQuery = [self.sqlQueryA,char(startTime),self.sqlQueryB,char(stopTime),self.sqlQueryD1,tag,sqlf.sqlQueryD2];
-        sqlQuery = [self.sqlQueryAA,char(startTime),self.sqlQueryB,char(stopTime),self.sqlQueryD1,tag,self.sqlQueryD2];
+        sqlQuery = [self.sqlQueryAA, char(startTime), self.sqlQueryB, char(stopTime), ...
+                    self.sqlQueryD1, strcat('''', tag, ''''), self.sqlQueryD2];
         if DeBug
           fid = fopen([self.data_dir_path,filesep,'debug.sql'],'at');
           fprintf(fid,'%s\n',sqlQuery);


### PR DESCRIPTION
When generating SQL for reading from a JDBC source, need to quote the tag name if that input table is 'row-based' rather than 'column-based'.  See issue #3.